### PR TITLE
Deny panic-based lints (unwrap, expect, panic)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ readme = "README.md"
 keywords = ["bevy", "gamedev", "asset"]
 categories = ["game-development"]
 
+[lints]
+workspace = true
+
+[workspace.lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+
 [dependencies]
 bevy = { version = "0.14", default-features = false, features = [
     "bevy_asset",

--- a/src/assetformat.rs
+++ b/src/assetformat.rs
@@ -117,6 +117,7 @@ fn parse_bounds(size: String) -> Result<Rect, LibGdxAtlasAssetError> {
     Ok(Rect::new(x as f32, y as f32, x2 as f32, y2 as f32))
 }
 
+#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use super::*;
@@ -125,14 +126,12 @@ mod test {
 
     #[test]
     fn test_parse_size() {
-        #[allow(clippy::unwrap_used)]
         let size = parse_size("size:12,14".into()).unwrap();
         assert_eq!(size, IVec2::new(12, 14));
     }
 
     #[test]
     fn test_parse_bounds() {
-        #[allow(clippy::unwrap_used)]
         let size = parse_bounds("bounds:1,2,10,20".into()).unwrap();
         assert_eq!(size, Rect::new(1., 2., 11., 22.));
     }

--- a/src/assetformat.rs
+++ b/src/assetformat.rs
@@ -70,10 +70,12 @@ fn parse_size(size: String) -> Result<IVec2, LibGdxAtlasAssetError> {
         ));
     }
 
-    let colon = size.find(':').expect("no colon found");
+    let colon = size.find(':').ok_or(LibGdxAtlasAssetError::ParsingError(
+        "expected symbol: ':'".to_string(),
+    ))?;
 
     let comma = size.find(',').ok_or(LibGdxAtlasAssetError::ParsingError(
-        "expected symbol: 'x'".into(),
+        "expected symbol: 'x'".to_string(),
     ))?;
 
     let w = size[colon.saturating_add(1)..comma].parse::<u32>()?;
@@ -85,11 +87,13 @@ fn parse_size(size: String) -> Result<IVec2, LibGdxAtlasAssetError> {
 fn parse_bounds(size: String) -> Result<Rect, LibGdxAtlasAssetError> {
     if !size.starts_with("bounds:") {
         return Err(LibGdxAtlasAssetError::ParsingError(
-            "expected: 'bounds:'".into(),
+            "expected: 'bounds:'".to_string(),
         ));
     }
 
-    let colon = size.find(':').expect("no colon found");
+    let colon = size.find(':').ok_or(LibGdxAtlasAssetError::ParsingError(
+        "expected symbol: ':'".to_string(),
+    ))?;
 
     let mut values = size[colon.saturating_add(1)..].split(',');
 
@@ -121,12 +125,14 @@ mod test {
 
     #[test]
     fn test_parse_size() {
+        #[allow(clippy::unwrap_used)]
         let size = parse_size("size:12,14".into()).unwrap();
         assert_eq!(size, IVec2::new(12, 14));
     }
 
     #[test]
     fn test_parse_bounds() {
+        #[allow(clippy::unwrap_used)]
         let size = parse_bounds("bounds:1,2,10,20".into()).unwrap();
         assert_eq!(size, Rect::new(1., 2., 11., 22.));
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,24 +16,30 @@ use thiserror::Error;
 pub enum LibGdxAtlasAssetError {
     /// An [IO](std::io) Error that occured
     /// during parsing of a `.libgdx.atlas` file.
-    #[error("Could not load asset: {0}")]
+    #[error("could not load asset: {0}")]
     Io(#[from] std::io::Error),
 
     /// A Bevy [`LoadDirectError`](bevy::asset::LoadDirectError) that occured
     /// while loading a [`LibGdxAtlasAsset::image`](crate::LibGdxAtlasAsset::image).
-    #[error("Could not load asset: {0}")]
+    #[error("could not load asset: {0}")]
     LoadDirect(Box<bevy::asset::LoadDirectError>),
 
     /// An error that occurs when parsing the
     /// content of a `.libgdx.atlas` file.
-    #[error("Parse error: {0}")]
+    #[error("parse error: {0}")]
     ParsingError(String),
 
     /// An error that can occur when
     /// parsing the size of a `.libgdx.atlas`'s
     /// texture atlas.
-    #[error("Parse Int error: {0}")]
+    #[error("parse Int error: {0}")]
     ParsingInt(#[from] std::num::ParseIntError),
+
+    /// An error that can occur if there is
+    /// trouble loading the image asset of
+    /// an atlas.
+    #[error("missing image asset: {0}")]
+    LoadingImageAsset(String),
 }
 
 impl From<bevy::asset::LoadDirectError> for LibGdxAtlasAssetError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@
 //!
 //! Now when you load files with the `.libgdx.atlas` extension through the asset server, or even `bevy_asset_loader`, they will load as a [`LibGdxAtlasAsset`] which you can then use.
 
-#![deny(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
-
 mod assetformat;
 mod error;
 mod loader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! Now when you load files with the `.libgdx.atlas` extension through the asset server, or even `bevy_asset_loader`, they will load as a [`LibGdxAtlasAsset`] which you can then use.
 
+#![deny(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+
 mod assetformat;
 mod error;
 mod loader;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -32,7 +32,9 @@ impl AssetLoader for LibGdxAtlasAssetLoader {
             .asset_path()
             .path()
             .parent()
-            .unwrap()
+            .ok_or(LibGdxAtlasAssetError::LoadingImageAsset(
+                "can't find parent folder common to atlas and image asset".to_string(),
+            ))?
             .join(asset.file);
 
         let image: Image = load_context
@@ -42,7 +44,9 @@ impl AssetLoader for LibGdxAtlasAssetLoader {
             .load(path)
             .await?
             .take()
-            .expect("expected image asset");
+            .ok_or(LibGdxAtlasAssetError::LoadingImageAsset(
+                "failed to load image asset, does it exist".to_string(),
+            ))?;
 
         let mut layout = TextureAtlasLayout::new_empty(asset.size.as_uvec2());
         let mut files = HashMap::new();


### PR DESCRIPTION
This way we make sure we don't panic whilst loading an asset, instead preferring errors and letting the user handle scenarios if possible.